### PR TITLE
Mergesplit function - remove global assignment of return dictionary

### DIFF
--- a/code/processes/qmerger.q
+++ b/code/processes/qmerger.q
@@ -51,7 +51,7 @@ mergesplit:{
   // build return dictionary
   b:`=(merged?0b)[`split];
   returnkeys:`loadid`mergelocation`fullmergestatus;
-  return::result,returnkeys!(x[`loadid];quotedir;b)
+  result,returnkeys!(x[`loadid];quotedir;b)
   };
 
 // move merged quotes to date partition in hdb


### PR DESCRIPTION
Remove global assignment of return dictionary in mergesplit in order to properly get return dictionary to orchestrator.
