### PR TITLE
Bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ The TorQ-TAQ Loader architecture is an extension to TorQ, which efficiently load
 
 To download TorQ TAQ, get latest installation script and download it to the directory where you want your codebase to live
 
-`wget https://raw.githubusercontent.com/AquaQAnalytics/TorQ-TAQ/master/installlatest.sh`
+````
+wget https://raw.githubusercontent.com/AquaQAnalytics/TorQ-TAQ/master/installlatest.sh
+````
 
 Then run the following line in the same working directory
 
@@ -101,7 +103,7 @@ Here we just want to load in the NYSE trade data for date partition 2022.10.03 a
 2023.02.07D16:13:07.537313000|homer.aquaq.co.uk|orchestrator|orchestrator1|INF|alerter|adding /home/user/deploy/data/filedrop/EQY_US_ALL_TRADE_20221003.gz to alreadyprocessed table
 2023.02.07D16:13:07.537322000|homer.aquaq.co.uk|orchestrator|orchestrator1|INF|alerter|saving alreadyprocessed table to disk  
  ````
-3. Once the trade file has finished loading in, we can locate it within `deploy/tempdb/final/YYYY.MM.DD/trade`
+3. Once the trade file has finished loading in, we can locate it within `deploy/tempdb/final/2022.10.03/trade`
 ````
 hdb
 └── sym
@@ -160,4 +162,5 @@ tempdb
     └── 2022.10.03
 ````
 
-An overview blog [is here](https://www.aquaq.co.uk/q/torq-taq-a-nyse-taq-loader/), further documentation is in the docs [directory](docs/torqtaqtutorial.md). 
+
+>An overview blog [is here](https://www.aquaq.co.uk/q/torq-taq-a-nyse-taq-loader/), further documentation is in the docs [directory](docs/torqtaqtutorial.md). 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Here we just want to load in the NYSE trade data for date partition 2022.10.03 a
   
     `wget https://ftp.nyse.com/Historical%20Data%20Samples/DAILY%20TAQ/EQY_US_ALL_TRADE_20221003.gz`
 
-2. After this download is complete, the orchestrator will pick up on this file and being to decompress it within a taqloader process - an example log of this is shown below 
+2. After this download is complete, the orchestrator will pick up on this file and begin to decompress it within a taqloader process - an example log of this is shown below 
  ````
  2023.02.07D16:13:04.283306000|homer.aquaq.co.uk|orchestrator|orchestrator1|INF|alerter|running filealerter process
 2023.02.07D16:13:04.283375000|homer.aquaq.co.uk|orchestrator|orchestrator1|INF|alerter|searching for /home/user/deploy/data/filedrop/*.gz

--- a/README.md
+++ b/README.md
@@ -1,4 +1,33 @@
 # TorQ-TAQ
 NYSE TAQ Loader in using kdb+ and TorQ
 
-An overview blog [is here](https://www.aquaq.co.uk/q/torq-taq-a-nyse-taq-loader/), further documentation is in the docs directory. 
+# Quick Installisation
+
+To download TorQ TAQ, get latest installation script and download it to the directory where you want your codebase to live
+
+`wget https://raw.githubusercontent.com/AquaQAnalytics/TorQ-TAQ/master/installlatest.sh`
+
+Then run the following line in the same working directory
+
+`bash installlatest.sh`
+
+Once this is complete, the necessary TorQ packages will be installed 
+````
+.
+├── datatemp
+│   ├── filedrop
+│   ├── logs
+│   ├── tplogs
+│   ├── wdb
+│   └── wdbhdb
+├── deploy
+│   ├── bin
+│   ├── data -> ~/torq/datatemp
+│   ├── TorQ
+│   └── TorQApp
+├── installlatest.sh
+├── installtorqapp.sh
+├── TorQ-4.3.0.tar.gz
+└── TorQ-TAQ-1.0.0.tar.gz
+````
+An overview blog [is here](https://www.aquaq.co.uk/q/torq-taq-a-nyse-taq-loader/), further documentation is in the docs [directory](docs/torqtaqtutorial.md). 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # TorQ-TAQ
-NYSE TAQ Loader in using kdb+ and TorQ
+
+The TorQ-TAQ Loader architecture is an extension to TorQ, which efficiently loads NYSE TAQ files using the streaming decompress algorithm with .Q.fpn  
 
 # Quick Installisation
 
@@ -22,7 +23,7 @@ Once this is complete, the necessary TorQ packages will be installed
 │   └── wdbhdb
 ├── deploy
 │   ├── bin
-│   ├── data -> ~/torq/datatemp
+│   ├── data -> ~/datatemp
 │   ├── TorQ
 │   └── TorQApp
 ├── installlatest.sh
@@ -30,4 +31,133 @@ Once this is complete, the necessary TorQ packages will be installed
 ├── TorQ-4.3.0.tar.gz
 └── TorQ-TAQ-1.0.0.tar.gz
 ````
+# Running TorQ-TAQ
+To start TorQ TAQ, run the following command within your terminal:
+
+````
+$ ./bin/torq.sh start all
+15:36:23 | Starting discovery1...
+15:36:23 | Starting gateway1...
+15:36:23 | Starting orchestrator1...
+15:36:23 | Starting taqloader1...
+15:36:24 | Starting taqloader2...
+15:36:24 | Starting qmerger1...
+
+$ ./bin/torq.sh summary
+TIME      |  PROCESS        |  STATUS  |  PID    |  PORT
+15:36:56  |  discovery1     |  up      |  21434  |  10610
+15:36:57  |  gateway1       |  up      |  21607  |  10611
+15:36:57  |  orchestrator1  |  up      |  21978  |  10612
+15:36:57  |  taqloader1     |  up      |  22097  |  10613
+15:36:57  |  taqloader2     |  up      |  22209  |  10614
+15:36:58  |  qmerger1       |  up      |  22320  |  10615
+````
+
+The user must download TAQ .gz files to a directory on disk called filedrop in the upper-level TorQ directory.  At this point, the orchestrator will recognise a new file exists in this filedrop directory and invoke a loader process. 
+
+Three files are currently supported: trade, quote, and national best bid offer (nbbo).  These files have the form:
+
+- `EQY_US_ALL_TRADE_YYYYMMDD.gz` *(Trades)* 
+- `EQY_US_ALL_NBBO_YYYYMMDD.gz` *(National Best Bid Offer)* 
+- `SPLITS_US_ALL_BBO_*_YYYYMMDD.gz` *(Best Bid Offer - 26 files per day)* 
+
+Depending on if the file recognised is a trade, quote or nbbo file, the way the data is saved behaves differently. 
+
+## Trade/NBBO ##
+Trade/NBBO data is laoded to the temporary HDB - tempdb, located in `deploy/tempdb/final/YYYY.MM.DD/trade|nbbo/`
+
+**_NOTE:_** tempdb and hdb directories are created once a TAQ .gz file is loaded in - the paths to these directories are defined within [default.q](appconfig/settings/default.q)
+
+By default, when Trade/NBBO data is loaded to the temporary HDB, it lives in the `deploy/tempdb/final/YYYY.MM.DD/` directory until all data from this day has been loaded. 
+
+## Quote ##
+
+Quote data is loaded to `deploy/tempdb/quote*/YYYY.MM.DD/quote/`
+
+It is important to note that for the quote files, there are 26 split files (A-Z) and so when quote data is loaded, it is saved in the tempdb directory but saved as a partition of the quote split file that is being loaded (quoteA, quoteB, quoteC etc.). 
+
+When the quote split file has been loaded successfully, it is merged using the merger process.  This merger process merges the quote split file to the same location as the trade and/or nbbo data in deploy/tempdb/final/YYYY.MM.DD/quote.  The split files do not have to be loaded in alphabetical order; i.e., split file B can be loaded and merged before split file A.
+
+When the trade, nbbo and all 26 quote split files have been successfully loaded and merged, the orchestrator then calls the merge process to call the function which moves all of the loaded and merged data to the final hdb in its relevant date partition.
+
+## Support Functionality ##
+
+We have included a function called `manualmovetohdb` – This function can be called with arguments `[date;filetype]` in the orchestrator to manually move loaded data to the hdb. date is a date atom and filetype is a symbol or list of symbols (any of trade, quote, or nbbo). By default, data is only moved when all files have been successfully loaded and merged. However, this can be called to move the data at a different point in time.
+
+## Example ##
+Here we just want to load in the NYSE trade data for date partition 2022.10.03 and manually move it to the HDB
+
+1. Begin by downloading EQY_US_ALL_TRADE_20221003.gz from the NYSE website directly into your filedrop directory whilst your stacks are up
+  
+    `wget https://ftp.nyse.com/Historical%20Data%20Samples/DAILY%20TAQ/EQY_US_ALL_TRADE_20221003.gz`
+
+2. After this download is complete, the orchestrator will pick up on this file and being to decompress it within a taqloader process - an example log of this is shown below 
+ ````
+ 2023.02.07D16:13:04.283306000|homer.aquaq.co.uk|orchestrator|orchestrator1|INF|alerter|running filealerter process
+2023.02.07D16:13:04.283375000|homer.aquaq.co.uk|orchestrator|orchestrator1|INF|alerter|searching for /home/user/deploy/data/filedrop/*.gz
+2023.02.07D16:13:07.537137000|homer.aquaq.co.uk|orchestrator|orchestrator1|INF|alerter|found file /home/user/deploy/data/filedrop/EQY_US_ALL_TRADE_20221003.gz
+2023.02.07D16:13:07.537172000|homer.aquaq.co.uk|orchestrator|orchestrator1|INF|alerter|running function runload on /home/user/deploy/data/filedrop/EQY_US_ALL_TRADE_20221003.gz
+2023.02.07D16:13:07.537276000|homer.aquaq.co.uk|orchestrator|orchestrator1|INF|runload|Initiating loader process
+2023.02.07D16:13:07.537313000|homer.aquaq.co.uk|orchestrator|orchestrator1|INF|alerter|adding /home/user/deploy/data/filedrop/EQY_US_ALL_TRADE_20221003.gz to alreadyprocessed table
+2023.02.07D16:13:07.537322000|homer.aquaq.co.uk|orchestrator|orchestrator1|INF|alerter|saving alreadyprocessed table to disk  
+ ````
+3. Once the trade file has finished loading in, we can locate it within `deploy/tempdb/final/YYYY.MM.DD/trade`
+````
+hdb
+└── sym
+tempdb
+└── final
+    └── 2022.10.03
+        └── trade
+            ├── cond
+            ├── corr
+            ├── cts
+            ├── exch
+            ├── parttime
+            ├── price
+            ├── sequence
+            ├── size
+            ├── stop
+            ├── sym
+            ├── ticktime
+            ├── tradeid
+            └── trf
+````
+
+4. Because we have only downloaded the trade data for this date, we would need to call the manualmovetohdb function inside the orchestrator process
+````
+q)/ connect to orchestrator process
+q)h:hopen`::10612:admin:admin 
+q)h"manualmovetohdb"
+{[date;filetype]
+    h:.servers.getserverbytype[`gateway;`w;`any];
+        .lg.o[`startmovetohdb;"Moving ",(string filetype), " to hdb"]
+        (neg h)(`.gw.asyncexecjpt;(`manmovetohdb;date;filetype);`qmerger;{x};..
+  }
+q)h"manualmovetohdb[2022.10.03;`trade]"
+````
+Now the data should be moved from the tempdb to the hdb directory
+````
+hdb
+├── 2022.10.03
+│   └── trade
+│       ├── cond
+│       ├── corr
+│       ├── cts
+│       ├── exch
+│       ├── parttime
+│       ├── price
+│       ├── sequence
+│       ├── size
+│       ├── stop
+│       ├── sym
+│       ├── ticktime
+│       ├── tradeid
+│       └── trf
+└── sym
+tempdb
+└── final
+    └── 2022.10.03
+````
+
 An overview blog [is here](https://www.aquaq.co.uk/q/torq-taq-a-nyse-taq-loader/), further documentation is in the docs [directory](docs/torqtaqtutorial.md). 

--- a/code/processes/orchestrator.q
+++ b/code/processes/orchestrator.q
@@ -39,14 +39,14 @@ finishload:{[q;r]
         fileloading[loadid]:@[fileloading[loadid];`loadendtime`loadstatus`loadmessage;:;(.proc.cp[];0h;r)];
         .lg.o[`finishload;r];:()];
     // updated monitoring stats
-    fileloading[r[`loadid]]:@[fileloading[r[`loadid]];`loadendtime`loadstatus`loadmessage;:;(r[`loadendtime];r[`loadstatus];r[`loadmessage])];
+    fileloading[r[`loadid]]:first each@[fileloading[r[`loadid]];`loadendtime`loadstatus`loadmessage;:;(r[`loadendtime];r[`loadstatus];r[`loadmessage])];
     // if filetype is a quote invoke merger here
-    if[(r[`tabletype]~`quote) and "success"~r[`loadmessage];
+    if[(`quote~first r[`tabletype]) and ("success"~first r[`loadmessage]);
         fileloading[r[`loadid]]:@[fileloading[r[`loadid]];`mergestarttime;:;.proc.cp[]];
         h:.servers.getserverbytype[`gateway;`w;`any];
-        (neg h)(`.gw.asyncexecjpt;(`mergesplit;4#r);`qmerger;{x};`finishmerge;0Wn)];
+        (neg h)(`.gw.asyncexecjpt;(`mergesplit;first r);`qmerger;{x};`finishmerge;0Wn)];
         // if quotes are finihsed before nbbo and trade, call movetohdb here
-    if[mergecomplete and 2=sum exec loadstatus from fileloading where loadstatus=1h,filetype in `trade`nbbo;startmovetohdb[r[`tabledate]]];
+    if[mergecomplete and 2=sum exec loadstatus from fileloading where loadstatus=1h,filetype in `trade`nbbo;startmovetohdb[first r[`tabledate];first r[`tabletype]]];
   };
 
 finishmerge:{[q;r]
@@ -55,17 +55,17 @@ finishmerge:{[q;r]
     fileloading[r[`loadid]]:@[fileloading[r[`loadid]];`mergeendtime`mergestatus`mergemessage;:;(r[`mergeendtime];r[`mergestatus];r[`mergemessage])];
     if[1b~r[`fullmergestatus];mergecomplete::1b];
     // if trade and nbbo are finished before quotes, movetohdb called here
-    if[mergecomplete and 2=sum exec loadstatus from fileloading where loadstatus=1h,filetype in `trade`nbbo;startmovetohdb[r[`tabledate]]];
+    if[mergecomplete and 2=sum exec loadstatus from fileloading where loadstatus=1h,filetype in `trade`nbbo;startmovetohdb[first r[`tabledate];first r[`tabletype]]];
   };
 
 finishmovetohdb:{[q;r]
     .lg.o[`finishmovetohdb;"Merged quote data, trade and nbbo data have successfully been moved to hdb"]
   };
 
-startmovetohdb:{[d]
+startmovetohdb:{[d;files]
     h:.servers.getserverbytype[`gateway;`w;`any];
         .lg.o[`startmovetohdb;"Moving quote, trade and nbbo data to hdb"]
-        (neg h)(`.gw.asyncexecjpt;(`movetohdb;d);`qmerger;{x};`finishmovetohdb;0Wn)
+        (neg h)(`.gw.asyncexecjpt;(`movepartohdb;d;files);`qmerger;{x};`finishmovetohdb;0Wn)
   };
 
 // async message to invoke loader process when new nyse file is found

--- a/code/processes/orchestrator.q
+++ b/code/processes/orchestrator.q
@@ -45,7 +45,7 @@ finishload:{[q;r]
         fileloading[r[`loadid]]:@[fileloading[r[`loadid]];`mergestarttime;:;.proc.cp[]];
         h:.servers.getserverbytype[`gateway;`w;`any];
         (neg h)(`.gw.asyncexecjpt;(`mergesplit;first r);`qmerger;{x};`finishmerge;0Wn)];
-        // if quotes are finihsed before nbbo and trade, call movetohdb here
+        // if quotes are finished before nbbo and trade, call movetohdb here
     if[mergecomplete and 2=sum exec loadstatus from fileloading where loadstatus=1h,filetype in `trade`nbbo;startmovetohdb[first r[`tabledate];first r[`tabletype]]];
   };
 

--- a/code/processes/qmerger.q
+++ b/code/processes/qmerger.q
@@ -1,10 +1,3 @@
-\d .taq
-
-hdbdir:@[value;`hdbdir;`:hdb]
-symdir:@[value;`symdir;`:symdir]
-tempdb:@[value;`tempdb;`:tempdb]
-mergedir:@[value;`mergedir;`:mergedir]
-
 \d .
 
 // reset temp hdb and update merged table

--- a/code/processes/taqloader.q
+++ b/code/processes/taqloader.q
@@ -25,7 +25,7 @@ loadtaqfile:{[taqloaderparams;optionalparams]
         .lg.e[`loadtaqfile;errmsg:("Could not extract date in "),string taqloaderparams`filetoload];
         :buildreturndict[returndict;0h;errmsg]];
     // Check if file exists in filedrop directory, otherwise exit with error
-    $[taqloaderparams[`filetoload] in key[filedrop];
+    $[taqloaderparams[`filetoload] in key[.taq.filedrop];
         .lg.o[`loadtaqfile;raze "File successfully found in ",getenv[`TORQTAQFILEDROP]];
         doload:0b];
     if[not doload;.lg.e[`loadtaqfile;

--- a/code/processes/taqloader.q
+++ b/code/processes/taqloader.q
@@ -1,6 +1,6 @@
-hdbdir:@[value;`hdbdir;`:hdbdir]
-symdir:@[value;`symdir;`:symdir]
-tempdb:@[value;`tempdb;`:tempdb]
+hdbdir:@[value;`hdbdir;.taq.hdbdir]
+symdir:@[value;`symdir;.taq.symdir]
+tempdb:@[value;`tempdb;.taq.tempdb]
 filedrop:@[value;`filedrop;`:filedrop]
 optionalparams:@[value;`optionalparams;()!()]
 
@@ -69,7 +69,7 @@ executeload:{[p;fp;ftl;d;ft;em]
         {[e] .lg.e[`loadtaqfile;msg:"Failed to complete load with error: ",e];(0b;msg)}];
     if[0b~first loadmsg;:buildreturndict[d;0h;last loadmsg]];
     .lg.o[`fifoloader;(string ftl)," has successfully been loaded"];
-    syscmd["rm ",fifo];
+    syscmd["rm -f ",fifo];
     // assign value to table path only if table is successfully loaded here
     d[`tablepath]:hsym`$(string p[`dbdir]),"/",(string d`tabledate),"/",(string ft);
     buildreturndict[d;1h;em]

--- a/setenv.sh
+++ b/setenv.sh
@@ -20,10 +20,10 @@ export KDBLOG=${TORQDATAHOME}/logs
 export KDBHTML=${TORQHOME}/html
 export KDBLIB=${TORQHOME}/lib
 export KDBHDB=${TORQDATAHOME}/hdb
-export TORQTAQTEMPDB=${TORQDATAHOME}}/tempdb
-export TORQTAQMERGED=${TORQDATAHOME}}/merged
+export TORQTAQTEMPDB=${TORQDATAHOME}/tempdb
+export TORQTAQMERGED=${TORQDATAHOME}/merged
 export TORQTAQFILEDROP=${TORQDATAHOME}/filedrop
-export KBDTESTS=${TORQHOME}/tests
+export KDBTESTS=${TORQHOME}/tests
 # set rlwrap and qcon paths for use in torq.sh qcon flag functions
 export RLWRAP="rlwrap"
 export QCON="qcon"


### PR DESCRIPTION
This PR includes minor bugfixes to TorQ TAQ. 

Most of the codebase is kept the same, the table loading order was untouched.

Any trade, nbbo or quote files dropped within filedrop will be picked up by the orchestrator and loaded in by the taqloaders. They will be saved within tempdb and remain there until all tables are loaded in or manually moved to the HDB via `manualmovetohdb[(manualmovetohdb[date;filetype]`

**orchestrator.q** 
- Fixed updates to fileloading table within `finishload` and `finishmerge`. This was failing with `type` error as `loadendtime`, `loadstatus` and `loadmessage` columns were all enlisted with singular values
- Added new argument `files` to `movepartohdb` as this was calling a non existing argument `movetohdb`. This now calls `movepartohdb` within the `qmerger` process

**qmerger.q**
- Removed unnecessary environment redefinition 

**taqloader.q**
- Fixed the environments so they are now pointing to the correct paths